### PR TITLE
add tubulo-interstitum for every cell type whose parent is tubules or interstitum

### DIFF
--- a/src/main/java/org/kpmp/cellTypeSummary/ClusterHiearchyRepository.java
+++ b/src/main/java/org/kpmp/cellTypeSummary/ClusterHiearchyRepository.java
@@ -24,13 +24,13 @@ interface ClusterHiearchyRepository extends CrudRepository<ClusterHierarchy, Clu
 
     // This query gets the regions or subregions that RT/RP data are in given a more specific cell type.
     @Cacheable("clusterHierarchy2025ByCellTypeRegionsSubregions")
-    @Query(value = "SELECT * FROM (SELECT v1.*, 0 AS cluster_id, v1.cell_type AS cluster_name, 'Y' AS is_rt, 'Y' AS is_rp, 'N' AS is_single_cell, 'N' as is_single_nuc FROM rt_segment_hierarchy_2025_v v1 " +
+    @Query(value = "SELECT * FROM (SELECT v1.*, 0 AS cluster_id, v1.cell_type AS cluster_name, 'Y' AS is_rt, 'N' AS is_rp, 'N' AS is_single_cell, 'N' as is_single_nuc FROM rt_segment_hierarchy_2025_v v1 " +
     "WHERE v1.cell_type IS NULL AND v1.structure_subregion IS NULL AND v1.structure_region IN (" +
             "SELECT v2.structure_region FROM cell_type_2025 v2 " +
                     "WHERE v2.cell_type = :cell_type OR " +
                     "v2.structure_subregion = :cell_type) " +
     "UNION " +
-    "SELECT v1.*, 0 AS cluster_id, v1.cell_type AS cluster_name, 'Y' AS is_rt, 'Y' AS is_rp, 'N' AS is_single_cell, 'N' as is_single_nuc FROM knowledge_environment.rt_segment_hierarchy_2025_v v1 " +
+    "SELECT v1.*, 0 AS cluster_id, v1.cell_type AS cluster_name, 'Y' AS is_rt, 'N' AS is_rp, 'N' AS is_single_cell, 'N' as is_single_nuc FROM knowledge_environment.rt_segment_hierarchy_2025_v v1 " +
     "WHERE v1.cell_type IS NULL AND v1.structure_subregion IN ( " +
             "SELECT v2.structure_subregion FROM cell_type_2025 v2 " +
                     "WHERE v2.cell_type = :cell_type OR " +

--- a/src/main/java/org/kpmp/cellTypeSummary/ClusterHierarchy.java
+++ b/src/main/java/org/kpmp/cellTypeSummary/ClusterHierarchy.java
@@ -135,4 +135,21 @@ public class ClusterHierarchy implements Serializable {
 	public void setCellType(String cellType) {
 		this.cellType = cellType;
 	}
+
+    @Override
+    public String toString() {
+        return "ClusterHierarchy{" +
+                "cellTypeId=" + cellTypeId +
+                ", clusterId=" + clusterId +
+                ", structureRegion='" + structureRegion + '\'' +
+                ", structureSubregion='" + structureSubregion + '\'' +
+                ", clusterName='" + clusterName + '\'' +
+                ", isSingleCellCluster='" + isSingleCellCluster + '\'' +
+                ", isSingleNucCluster='" + isSingleNucCluster + '\'' +
+                ", isRegionalTranscriptomics='" + isRegionalTranscriptomics + '\'' +
+                ", isRegionalProteomics='" + isRegionalProteomics + '\'' +
+                ", cellType='" + cellType + '\'' +
+                ", cellTypeOrder=" + cellTypeOrder +
+                '}';
+    }
 }

--- a/src/main/java/org/kpmp/cellTypeSummary/ClusterHierarchyService.java
+++ b/src/main/java/org/kpmp/cellTypeSummary/ClusterHierarchyService.java
@@ -40,9 +40,20 @@ public class ClusterHierarchyService {
                 clusterToHierarchy.put(clusterName, clusterHierarchy);
             }
         }
-        if (cellType.equals("Tubules") || cellType.equals("Interstitium") 
-            || cellType.equals("Proximal Tubule") || cellType.equals("Proximal Tubule Epithelial Cell")
-        || cellType.equals("Stroma / Mesenchymal") || cellType.equals("Perivascular Fibroblast")) {
+
+        boolean hasTubulesOrInterstitium = clusterHierarchiesParentRegions.stream()
+            .anyMatch(ch -> "Tubules".equals(ch.getStructureRegion()) 
+                    || "Interstitium".equals(ch.getStructureRegion()));
+
+        boolean hasTubulesOrInterstitiumRegional = clusterHierarchiesRegional.stream()
+        .anyMatch(ch -> "Tubules".equals(ch.getStructureRegion()) 
+                || "Interstitium".equals(ch.getStructureRegion()));
+
+        boolean hasTubulesOrInterstitiumRNASeq = clusterHierarchiesRNASeq.stream()
+        .anyMatch(ch -> "Tubules".equals(ch.getStructureRegion()) 
+                || "Interstitium".equals(ch.getStructureRegion()));
+
+        if (hasTubulesOrInterstitium || hasTubulesOrInterstitiumRegional || hasTubulesOrInterstitiumRNASeq || cellType.equals("Tubules") || cellType.equals("Interstitium")) {
             ClusterHierarchy tiCluster = new ClusterHierarchy();
             tiCluster.setStructureRegion("Tubulo-interstitium");
             tiCluster.setIsSingleCellCluster("N");

--- a/src/main/java/org/kpmp/geneExpressionSummary/GeneExpressionSummaryService2025.java
+++ b/src/main/java/org/kpmp/geneExpressionSummary/GeneExpressionSummaryService2025.java
@@ -165,12 +165,6 @@ public class GeneExpressionSummaryService2025 {
 				rpParticipantRepository.getCountByEnrollmentCategory(EnrollmentCategoryEnum.DMR.getParticipantEnrollmentCategory()),
 				rpParticipantRepository.getParticipantCount(),
 				rpParticipantRepository.getParticipantCount()));
-		dataTypeSummary.add(new DataTypeSummary(
-			OmicsTypeEnum.TRANSCRIPTOMICS.getEnum(), 
-			FullDataTypeEnum.SPATIAL_TRANSCRIPTOMICS.getFullName(), 
-			FullDataTypeEnum.SPATIAL_TRANSCRIPTOMICS.getAbbreviation(), 
-			1000L, 1000L, 1000L, 
-			1000L, 1000L, 1000L));
 		return dataTypeSummary;
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected regional transcriptomics data retrieval in cluster hierarchy queries to provide accurate cell type and region information
  * Refined tubulo-interstitium cluster detection to dynamically evaluate and identify clusters based on analyzed region data
  * Updated regional proteomics data sourcing to integrate with the latest data repository
  * Eliminated placeholder data entries from spatial transcriptomics summaries to ensure data accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->