### PR TITLE
preserve order of db results

### DIFF
--- a/src/main/java/org/kpmp/cellTypeSummary/ClusterHierarchyService.java
+++ b/src/main/java/org/kpmp/cellTypeSummary/ClusterHierarchyService.java
@@ -19,8 +19,8 @@ public class ClusterHierarchyService {
     public List<ClusterHierarchy> findClustersByCellType2025(String cellType) {
 
         ArrayList<ClusterHierarchy> result = new ArrayList<>();
-        Map<String, ClusterHierarchy> clusterToHierarchy = new HashMap<>();
-        Set<ClusterHierarchy> clusterHierarchySet = new HashSet<>();
+        Map<String, ClusterHierarchy> clusterToHierarchy = new LinkedHashMap<>();
+        Set<ClusterHierarchy> clusterHierarchySet = new LinkedHashSet<>();
         List<ClusterHierarchy> clusterHierarchiesRNASeq = clusterHierarchyRepo.findRnaSeqByCellTypeOrRegion(cellType);
         List<ClusterHierarchy> clusterHierarchiesRegional = clusterHierarchyRepo.findRTRPByCellTypeOrRegion(cellType);
         List<ClusterHierarchy> clusterHierarchiesParentRegions = clusterHierarchyRepo.findRTRPParentRegions(cellType);

--- a/src/test/java/org/kpmp/cellTypeSummary/ClusterHierarchyServiceTest.java
+++ b/src/test/java/org/kpmp/cellTypeSummary/ClusterHierarchyServiceTest.java
@@ -145,6 +145,26 @@ public class ClusterHierarchyServiceTest {
     }
 
     @Test
+    public void testFindClustersByCellType_preservesRnaSeqOrder2025() {
+        ClusterHierarchy clusterHierarchy1 = new ClusterHierarchy();
+        clusterHierarchy1.setClusterName("Podocyte (<i>degenerative<sup>3</sup></i>)");
+        clusterHierarchy1.setCellTypeOrder(1.0);
+        ClusterHierarchy clusterHierarchy2 = new ClusterHierarchy();
+        clusterHierarchy2.setClusterName("Podocyte");
+        clusterHierarchy2.setCellTypeOrder(1.0);
+
+        List<ClusterHierarchy> hierarchiesRNA = new ArrayList<>(Arrays.asList(clusterHierarchy1, clusterHierarchy2));
+        List<ClusterHierarchy> hierarchiesRTRP = new ArrayList<>();
+        List<ClusterHierarchy> hierarchiesParent = new ArrayList<>();
+
+        when(clusterHierarchyRepo.findRTRPByCellTypeOrRegion("cell type")).thenReturn(hierarchiesRTRP);
+        when(clusterHierarchyRepo.findRnaSeqByCellTypeOrRegion("cell type")).thenReturn(hierarchiesRNA);
+        when(clusterHierarchyRepo.findRTRPParentRegions("cell type")).thenReturn(hierarchiesParent);
+
+        assertEquals(Arrays.asList(clusterHierarchy1, clusterHierarchy2), service.findClustersByCellType2025("cell type"));
+    }
+
+    @Test
     public void testFindDataTypesByClusterNameWhenBothY2025() throws Exception {
         ClusterHierarchy clusterHierarchy = new ClusterHierarchy();
         clusterHierarchy.setIsSingleCellCluster("Y");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster result ordering so entries now stay in the same sequence they were returned, making outputs more consistent and predictable.
  * Added test coverage to verify that RNA-seq cluster ordering is preserved when results are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->